### PR TITLE
feat(wicek): Home Assistant MCP + Apple Calendar env

### DIFF
--- a/charts/wicek/Chart.yaml
+++ b/charts/wicek/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 sources:
   - https://github.com/xxczaki/charts/tree/main/charts/wicek
 type: application
-version: 0.1.77
+version: 0.1.78
 appVersion: "da4b4de241f89b5c76337736a371363a258c8582"

--- a/charts/wicek/templates/deployment.yaml
+++ b/charts/wicek/templates/deployment.yaml
@@ -87,6 +87,20 @@ spec:
                   name: {{ .Values.secrets.haToken.name }}
                   key: {{ .Values.secrets.haToken.key }}
             {{- end }}
+            {{- if and .Values.secrets.appleId.name .Values.secrets.appleId.key }}
+            - name: APPLE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.appleId.name }}
+                  key: {{ .Values.secrets.appleId.key }}
+            {{- end }}
+            {{- if and .Values.secrets.appleAppPassword.name .Values.secrets.appleAppPassword.key }}
+            - name: APPLE_APP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.appleAppPassword.name }}
+                  key: {{ .Values.secrets.appleAppPassword.key }}
+            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/charts/wicek/templates/deployment.yaml
+++ b/charts/wicek/templates/deployment.yaml
@@ -80,6 +80,13 @@ spec:
                   name: {{ .Values.secrets.grafanaApiKey.name }}
                   key: {{ .Values.secrets.grafanaApiKey.key }}
             {{- end }}
+            {{- if and .Values.secrets.haToken.name .Values.secrets.haToken.key }}
+            - name: HA_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.haToken.name }}
+                  key: {{ .Values.secrets.haToken.key }}
+            {{- end }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/charts/wicek/templates/networkpolicy.yaml
+++ b/charts/wicek/templates/networkpolicy.yaml
@@ -28,11 +28,13 @@ spec:
     - ports:
         - port: 80
           protocol: TCP
-    # SSH to Tailscale devices
+    # SSH + Home Assistant MCP (8123) to Tailscale devices
     - to:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: tailscale
       ports:
         - port: 22
+          protocol: TCP
+        - port: 8123
           protocol: TCP

--- a/charts/wicek/values.yaml
+++ b/charts/wicek/values.yaml
@@ -15,6 +15,12 @@ secrets:
   grafanaApiKey:
     name: ""
     key: ""
+  # -- Points to a Secret containing the Home Assistant long-lived access token
+  # Authenticates to the Home Assistant MCP server. When unset, HA_TOKEN is not injected.
+  # @section -- Authentication
+  haToken:
+    name: ""
+    key: ""
   # -- Points to a Secret containing the Home Assistant SSH key
   # @section -- Authentication
   haSSHKey:

--- a/charts/wicek/values.yaml
+++ b/charts/wicek/values.yaml
@@ -21,6 +21,17 @@ secrets:
   haToken:
     name: ""
     key: ""
+  # -- Points to a Secret containing the Apple ID email (iCloud CalDAV)
+  # @section -- Authentication
+  appleId:
+    name: ""
+    key: ""
+  # -- Points to a Secret containing the Apple app-specific password (iCloud CalDAV)
+  # When appleId and appleAppPassword are both set, APPLE_ID/APPLE_APP_PASSWORD are injected.
+  # @section -- Authentication
+  appleAppPassword:
+    name: ""
+    key: ""
   # -- Points to a Secret containing the Home Assistant SSH key
   # @section -- Authentication
   haSSHKey:


### PR DESCRIPTION
Two wicek capabilities, chart `0.1.77` → `0.1.78`:

**Home Assistant MCP** — inject `HA_TOKEN` when `secrets.haToken` set; egress to `tailscale` ns on 8123.
**Apple Calendar (iCloud CalDAV)** — inject `APPLE_ID` + `APPLE_APP_PASSWORD` when `secrets.appleId`/`appleAppPassword` set.

⚠️ homelab#748 already merged and pins chart `0.1.78`, which only publishes once **this** merges — merge this to clear the failing wicek sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)